### PR TITLE
Give New Email Device Default Name When It Is Returned

### DIFF
--- a/two_factor/plugins/email/method.py
+++ b/two_factor/plugins/email/method.py
@@ -26,7 +26,7 @@ class EmailMethod(MethodBase):
             request.user.save(update_fields=['email'])
         device = EmailDevice.objects.devices_for_user(request.user).first()
         if not device:
-            device = EmailDevice(user=request.user)
+            device = EmailDevice(user=request.user, name='default')
         return device
 
     def get_token_form_class(self):


### PR DESCRIPTION
Users That Set Up 2FA By Email Are Not Currently Required To Enter 2FA Token To Log In

## Description
Currently, when a new `EmailDevice` is returned from `EmailMethod.get_device_from_setup_data()`, it is not given a name, so [`two_factor.utils.default_device`](https://github.com/jazzband/django-two-factor-auth/blob/master/two_factor/utils.py#L11-L19) is not able to find it, and as a result, a user can set up 2FA by email, but not be required to enter the 2FA code when logging in.

To this issue: when an `EmailDevice` is returned from `EmailMethod.get_device_from_setup_data()`, it is now given a name of `'default'`, matching the behavior of `YubikeyMethod.get_device_from_setup_data()` and `PhoneMethodBase.get_device_from_setup_data()`.


## Motivation and Context
This change makes 2FA by email work the same way that other 2FA methods work.

## How Has This Been Tested?
 - I created a new user
 - I logged in as the new user
 - I went to the /account/two_factor/setup/ URL to set up 2FA, clicked "Next", chose "Email", and correctly entered the token
 - I logged out
 - I logged back in with the same user, and I am now required to enter a 2FA token

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
